### PR TITLE
Fix header names

### DIFF
--- a/tests/obscuro/obs_cor_011/run.py
+++ b/tests/obscuro/obs_cor_011/run.py
@@ -9,8 +9,8 @@ class PySysTest(ObscuroNetworkTest):
         self.log.info('Last transactions are %s', txs)
         if len(txs) >= 1:
             batch = self.get_batch_for_transaction(txs[0])
-            parent_hash = batch['Header']['ParentHash']
-            number = batch['Header']['Number']
+            parent_hash = batch['Header']['parentHash']
+            number = batch['Header']['number']
             num_tx = len(batch['TxHashes'])
             self.log.info('Parent hash: %s, Number: %d, Ntx: %d', parent_hash, number, num_tx)
 
@@ -23,8 +23,8 @@ class PySysTest(ObscuroNetworkTest):
                     self.log.info(batch)
                     break
                 else:
-                    parent_hash = batch['Header']['ParentHash']
-                    number = batch['Header']['Number']
+                    parent_hash = batch['Header']['parentHash']
+                    number = batch['Header']['number']
                     num_tx = len(batch['TxHashes'])
                     self.log.info('Parent hash: %s, Number: %d, Ntx: %d', parent_hash, number, num_tx)
 

--- a/tests/obscuro/obs_cor_012/run.py
+++ b/tests/obscuro/obs_cor_012/run.py
@@ -30,7 +30,7 @@ class PySysTest(ObscuroNetworkTest):
 
         batch = self.get_batch_for_transaction(tx_hash)
         if batch is not None:
-            batch_number = batch['Header']['Number']
+            batch_number = batch['Header']['number']
             batch_txns = batch['TxHashes']
 
             self.log.info('batch details;')

--- a/tests/obscuro/obs_cor_014/run.py
+++ b/tests/obscuro/obs_cor_014/run.py
@@ -16,6 +16,6 @@ class PySysTest(ObscuroNetworkTest):
         # get the batch for transaction and from that the l1 proof
         batch = self.get_batch_for_transaction(tx_hash)
         self.log.info(batch)
-        l1_proof = batch['Header']['L1Proof']
+        l1_proof = batch['Header']['l1Proof']
         self.log.info(l1_proof)
 


### PR DESCRIPTION
The obscuro batch and header marshalling approach was not consistent and the names used here were wrong.
It would be `BatchHeader.ParentHash` when directly pulled the BatchHeader and `batch.Header.parentHash` when pulled the Batch.

The obscuro Batch and BatchHeader have the same marshalling/unmarshalling approach which means retrieving a Batch and consuming the Batch.Header now has the same fields as retrieving a BatchHeader (independently of the endpoints used).